### PR TITLE
Issues 302-303 GET/econews/count bugs fixed

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -27,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
@@ -313,8 +314,12 @@ public class EcoNewsController {
      * @author Mamchuk Orest
      */
     @ApiOperation(value = "Find count of published eco news")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = HttpStatuses.OK),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST)
+    })
     @GetMapping("/count")
-    public ResponseEntity<Long> findAmountOfPublishedNews(@RequestParam Long userId) {
+    public ResponseEntity<Long> findAmountOfPublishedNews(@RequestParam @NotNull Long userId) {
         return ResponseEntity.status(HttpStatus.OK).body(ecoNewsService.getAmountOfPublishedNewsByUserId(userId));
     }
 


### PR DESCRIPTION
Bugs fixed at GET/econews/count.
issue 302:   the 400 (Bad request) response code is documented in the response codes list;
issue 303:   send the request without "userId" value - the 400 (Bad request) response code is returned.