### PR TITLE
UserVOMapperTest fix

### DIFF
--- a/service/src/main/java/greencity/mapping/UserVOMapper.java
+++ b/service/src/main/java/greencity/mapping/UserVOMapper.java
@@ -45,6 +45,7 @@ public class UserVOMapper extends AbstractConverter<User, UserVO> {
             .showShoppingList(user.getShowShoppingList())
             .showEcoPlace(user.getShowEcoPlace())
             .showLocation(user.getShowLocation())
+            .lastActivityTime(user.getLastActivityTime())
             .build();
     }
 }

--- a/service/src/test/java/greencity/mapping/UserVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/UserVOMapperTest.java
@@ -57,6 +57,7 @@ class UserVOMapperTest {
                 .build() : null)
             .lastActivityTime(expected.getLastActivityTime())
             .build();
+        expected.setUserFriends(null);
 
         assertEquals(expected, mapper.convert(userToBeConverted));
     }


### PR DESCRIPTION
Fix UserVOMapperTest. Now test is passing and coverage is 100%. To fix this, lastActivityTime was added to UserVoMapper and in UserVOMapperTest list of user's friends was set to null, as User model doesn't has such field.  